### PR TITLE
Adds a new feature for pretty printing trees

### DIFF
--- a/pretty/README.md
+++ b/pretty/README.md
@@ -25,3 +25,20 @@ $ go run cmd/table/main.go
 2025/09/01 14:03:52 pretty: Perth     5386 1554769    869.4
 2025/09/01 14:03:52 pretty: Sydney    2058 4336374    1214.8
 ```
+
+**Tree**
+
+```sh
+$ go run cmd/tree/main.go
+
+2025/09/08 16:39:26 pretty: .
+2025/09/08 16:39:26 pretty: ├── README.md
+2025/09/08 16:39:26 pretty: ├── cmd
+2025/09/08 16:39:26 pretty: │   ├── progress
+2025/09/08 16:39:26 pretty: │   │   └── main.go
+2025/09/08 16:39:26 pretty: │   ├── table
+2025/09/08 16:39:26 pretty: │   │   └── main.go
+2025/09/08 16:39:26 pretty: │   └── tree
+2025/09/08 16:39:26 pretty: │       └── main.go
+2025/09/08 16:39:26 pretty: └── pretty.go
+```

--- a/pretty/cmd/tree/main.go
+++ b/pretty/cmd/tree/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/libraries/go/pretty"
+)
+
+func walk(path string) *pretty.Tree {
+	info, err := os.Stat(path)
+	if err != nil {
+		log.Panicln("main:", err)
+	}
+	node := &pretty.Tree{Value: info.Name()}
+	if info.IsDir() {
+		l, err := os.ReadDir(path)
+		if err != nil {
+			log.Panicln("main:", err)
+		}
+		for _, e := range l {
+			node.Elems = append(node.Elems, walk(filepath.Join(path, e.Name())))
+		}
+		// Sort the elements alphabetically for consistent output.
+		slices.SortFunc(node.Elems, func(a, b *pretty.Tree) int {
+			return strings.Compare(a.Value, b.Value)
+		})
+	}
+	return node
+}
+
+func main() {
+	pretty.PrintTree(walk("."))
+}

--- a/pretty/cmd/tree/main.go
+++ b/pretty/cmd/tree/main.go
@@ -15,18 +15,18 @@ func walk(path string) *pretty.Tree {
 	if err != nil {
 		log.Panicln("main:", err)
 	}
-	node := &pretty.Tree{Value: info.Name()}
+	node := &pretty.Tree{Name: info.Name()}
 	if info.IsDir() {
 		l, err := os.ReadDir(path)
 		if err != nil {
 			log.Panicln("main:", err)
 		}
 		for _, e := range l {
-			node.Elems = append(node.Elems, walk(filepath.Join(path, e.Name())))
+			node.Leaf = append(node.Leaf, walk(filepath.Join(path, e.Name())))
 		}
 		// Sort the elements alphabetically for consistent output.
-		slices.SortFunc(node.Elems, func(a, b *pretty.Tree) int {
-			return strings.Compare(a.Value, b.Value)
+		slices.SortFunc(node.Leaf, func(a, b *pretty.Tree) int {
+			return strings.Compare(a.Name, b.Name)
 		})
 	}
 	return node

--- a/pretty/pretty.go
+++ b/pretty/pretty.go
@@ -69,19 +69,19 @@ func PrintTable(data [][]string) {
 
 // Tree represents a node in a tree structure.
 type Tree struct {
-	Value string
-	Elems []*Tree
+	Name string
+	Leaf []*Tree
 }
 
 func printTree(tree *Tree, prefix string) {
-	for i, elem := range tree.Elems {
-		isLast := i == len(tree.Elems)-1
+	for i, elem := range tree.Leaf {
+		isLast := i == len(tree.Leaf)-1
 		branch := "├── "
 		if isLast {
 			branch = "└── "
 		}
-		log.Println("pretty:", prefix+branch+elem.Value)
-		if len(elem.Elems) > 0 {
+		log.Println("pretty:", prefix+branch+elem.Name)
+		if len(elem.Leaf) > 0 {
 			middle := "│   "
 			if isLast {
 				middle = "    "
@@ -93,6 +93,6 @@ func printTree(tree *Tree, prefix string) {
 
 // PrintTree prints the tree structure starting from the root node.
 func PrintTree(tree *Tree) {
-	log.Println("pretty:", tree.Value)
+	log.Println("pretty:", tree.Name)
 	printTree(tree, "")
 }

--- a/pretty/pretty.go
+++ b/pretty/pretty.go
@@ -66,3 +66,34 @@ func PrintTable(data [][]string) {
 		log.Println("pretty:", strings.Join(line, " "))
 	}
 }
+
+// Tree represents a node in a tree structure.
+type Tree struct {
+	Value string
+	Elems []*Tree
+}
+
+// A helper function to recursively print the tree structure.
+func printTree(tree *Tree, prefix string) {
+	for i, elem := range tree.Elems {
+		isLast := i == len(tree.Elems)-1
+		branch := "├── "
+		if isLast {
+			branch = "└── "
+		}
+		log.Println("pretty:", prefix+branch+elem.Value)
+		if len(elem.Elems) > 0 {
+			middle := "│   "
+			if isLast {
+				middle = "    "
+			}
+			printTree(elem, prefix+middle)
+		}
+	}
+}
+
+// PrintTree prints the tree structure starting from the root node.
+func PrintTree(tree *Tree) {
+	log.Println("pretty:", tree.Value)
+	printTree(tree, "")
+}

--- a/pretty/pretty.go
+++ b/pretty/pretty.go
@@ -73,7 +73,6 @@ type Tree struct {
 	Elems []*Tree
 }
 
-// A helper function to recursively print the tree structure.
 func printTree(tree *Tree, prefix string) {
 	for i, elem := range tree.Elems {
 		isLast := i == len(tree.Elems)-1


### PR DESCRIPTION
This pull request adds a new feature for printing trees and updates documentation to showcase this functionality. The main changes include the introduction of a `Tree` data structure, a new command-line tool for tree visualization, and enhancements to the `pretty` package to support tree printing.

**New tree printing feature:**

* Added a `Tree` struct and related functions (`PrintTree`, `printTree`) to `pretty/pretty.go` for representing and printing directory trees in a formatted style.

**Command-line tool:**

* Implemented `pretty/cmd/tree/main.go`, which recursively walks the current directory, builds a `Tree` structure, and prints it using the new tree printing functionality.

**Documentation update:**

* Updated `pretty/README.md` to include usage instructions and sample output for the new tree command.